### PR TITLE
Add selectable fields from the RTP

### DIFF
--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -61,71 +61,18 @@ document.addEventListener('turbolinks:load', function() {
     // Private methods
 
     function _setDradisFieldSelect($select) {
-      var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
-      if (rtpFields) {
-        var fields = rtpFields[$select.val()],
-            $fieldSelect = $select.closest('tr').find('[data-behavior=field-select]');
+      var $row = $select.closest('tr');
 
-        if ($select.val() in rtpFields){
-          if (fields.length > 0) {
-            $fieldSelect.empty();
-            fields.forEach(function(value) {
-              $fieldSelect
-                .removeAttr('disabled')
-                .append(
-                  $('<option></option>').attr('value', value).text(value)
-                );
-            });
-          }
-          else {
-            var header = $fieldSelect.data('header');
-            $fieldSelect
-              .html(
-                $('<option disabled="disabled" selected></option>').attr('value', header).text(header)
-              );
-          }
-        } else if ($select.val()== 'node') {
-          $fieldSelect
-            .attr('disabled', 'disabled')
-            .html(
-              $('<option></option>').attr('value', '').text('Label')
-            );
-        } else {
-          $fieldSelect
-            .attr('disabled', 'disabled')
-            .html(
-              $('<option></option>').attr('value', '').text('N/A')
-            );
-        }
+      $row.find('.field-select').attr('disabled', 'disabled').addClass('d-none');
+      if ($select.val() == 'issue') {
+        $row.find('[data-behavior=issue-field-select]').removeAttr('disabled', 'disabled').removeClass('d-none');
       }
-    }
-
-    function _disableIdentifierRow($row) {
-      var $fieldSelect = $row.find('[data-behavior=field-select]'),
-          $typeSelect = $row.find('[data-behavior=type-select]');
-
-      $typeSelect.attr('disabled', 'disabled');
-      $typeSelect.val('issue').change();
-
-      $fieldSelect.attr('disabled', 'disabled');
-      // With RTP
-      $fieldSelect.html($('<option selected></option>').attr('value', 'plugin_id').text('plugin_id'));
-      // With no RTP
-      $row.find('[data-behavior=field-label]').text('plugin_id');
-    }
-
-    function _resetRow($row) {
-      var $fieldSelect = $row.find('[data-behavior=field-select]'),
-          $typeSelect = $row.find('[data-behavior=type-select]'),
-          $fieldLabel = $row.find('[data-behavior=field-label]');
-
-      $fieldSelect.removeAttr('disabled');
-      $typeSelect.removeAttr('disabled');
-
-      // With RTP
-      _setDradisFieldSelect($typeSelect);
-      // With no RTP
-      $fieldLabel.text($fieldLabel.data('header'));
+      else if ($select.val() == 'evidence') {
+        $row.find('[data-behavior=evidence-field-select]').removeAttr('disabled').removeClass('d-none');
+      }
+      else {
+        $row.find('[data-behavior=empty-field-select]').removeAttr('disabled').removeClass('d-none');
+      }
     }
 
     function _validateNodeSelected() {

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -44,14 +44,6 @@ document.addEventListener('turbolinks:load', function() {
       _setDradisFieldSelect($(this));
     });
 
-    $('[data-behavior=identifier]').on('mousedown', function(e){
-      var $previousRow = $('[data-behavior=identifier]:checked').closest('tr'),
-          $currentRow = $(this).closest('tr');
-
-      _resetRow($previousRow);
-      _disableIdentifierRow($currentRow);
-    });
-
     $('[data-behavior~=mapping-form]').submit(function() {
       var valid = _validateIdentifierSelected() && _validateNodeSelected();
 

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -15,9 +15,10 @@ window.addEventListener('job-done', function(e){
 
 document.addEventListener('turbolinks:load', function() {
   if ($('body.upload.new').length) {
-    $('[data-behavior=type-select]').on('change', function() {
+    $('[data-behavior=type-select]').on('change', function(e) {
       var $nodeSelect = $('select option[value="node"]:selected').parent();
 
+      // Disable Node Label option and update fields column labels
       $('[data-behavior=type-select]').each(function(i, select) {
         var $tr = $(select).closest('tr');
 
@@ -30,9 +31,22 @@ document.addEventListener('turbolinks:load', function() {
           $(select).find('option[value="node"]').removeAttr('disabled');
         }
       });
-
       $nodeSelect.closest('tr').find('[data-behavior=na-field-label]').removeClass('d-none');
       $nodeSelect.closest('tr').find('[data-behavior=default-field-label]').addClass('d-none');
+
+      // Update the field select with the one from the RTP
+      var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
+      if (rtpFields) {
+        var fields = rtpFields[$(e.target).val()],
+            $fieldSelect = $(e.target).closest('tr').find('[data-behavior=field-select]');
+
+        $fieldSelect.empty();
+        if (fields) {
+          fields.forEach(function(value) {
+            $fieldSelect.append($('<option></option>').attr('value', value).text(value));
+          });
+        }
+      }
     });
   }
 });

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -37,14 +37,17 @@ document.addEventListener('turbolinks:load', function() {
       // Update the field select with the one from the RTP
       var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
       if (rtpFields) {
-        var fields = rtpFields[$(e.target).val()],
+        var fields = rtpFields[$(e.target).val()] || [],
             $fieldSelect = $(e.target).closest('tr').find('[data-behavior=field-select]');
 
-        $fieldSelect.empty();
-        if (fields) {
+        if (fields.length > 0) {
+          $fieldSelect.empty();
           fields.forEach(function(value) {
             $fieldSelect.append($('<option></option>').attr('value', value).text(value));
           });
+        }
+        else {
+          $fieldSelect.html($('<option disabled="disabled" selected></option>').attr('value', '').text('N/A'));
         }
       }
     });

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -37,39 +37,19 @@ document.addEventListener('turbolinks:load', function() {
         $fieldLabel.text(header);
       }
 
-      setDradisFieldSelect($(this));
+      _setDradisFieldSelect($(this));
     });
 
     $('[data-behavior=identifier]').on('mousedown', function(e){
-      var $currentRow = $(this).closest('tr'),
-          $fieldSelect = $currentRow.find('[data-behavior=field-select]'),
-          $typeSelect = $currentRow.find('[data-behavior=type-select]');
+      var $previousRow = $('[data-behavior=identifier]:checked').closest('tr'),
+          $currentRow = $(this).closest('tr');
 
-      $typeSelect.attr('disabled', 'disabled');
-      $typeSelect.val('issue').change();
-
-      $fieldSelect.attr('disabled', 'disabled');
-      // With RTP
-      $fieldSelect.html($('<option selected></option>').attr('value', 'plugin_id').text('plugin_id'));
-      // With no RTP
-      $currentRow.find('[data-behavior=field-label]').text('plugin_id');
-
-      var $prevRow = $('[data-behavior=identifier]:checked').closest('tr');
-          $prevFieldSelect = $prevRow.find('[data-behavior=field-select]'),
-          $prevTypeSelect = $prevRow.find('[data-behavior=type-select]');
-
-      $prevFieldSelect.removeAttr('disabled');
-      $prevTypeSelect.removeAttr('disabled');
-
-      // With RTP
-      setDradisFieldSelect($prevTypeSelect);
-      // With no RTP
-      var header = $prevRow.find('[data-behavior=field-label]').data('header');
-      $prevRow.find('[data-behavior=field-label]').text(header);
+      _resetRow($previousRow);
+      _disableIdentifierRow($currentRow);
     });
 
     $('[data-behavior~=mapping-form]').submit(function() {
-      var valid = validateNodeSelected();
+      var valid = _validateNodeSelected();
 
       if (!valid) {
         $(this).find('input[type="submit"]').attr('disabled', false).val('Import CSV');
@@ -82,7 +62,66 @@ document.addEventListener('turbolinks:load', function() {
       return valid;
     });
 
-    function validateNodeSelected() {
+    // Private methods
+
+    function _setDradisFieldSelect($select) {
+      var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
+      if (rtpFields) {
+        var fields = rtpFields[$select.val()] || [],
+            $fieldSelect = $select.closest('tr').find('[data-behavior=field-select]');
+
+        if (fields.length > 0) {
+          $fieldSelect.empty();
+          fields.forEach(function(value) {
+            $fieldSelect
+              .removeAttr('disabled')
+              .append(
+                $('<option></option>')
+                .attr('value', value)
+                .text(value)
+              );
+          });
+        } else {
+          $fieldSelect
+            .attr('disabled', 'disabled')
+            .html(
+              $('<option selected></option>')
+              .attr('value', '')
+              .text('N/A')
+            );
+        }
+      }
+    }
+
+    function _disableIdentifierRow($row) {
+      var $fieldSelect = $row.find('[data-behavior=field-select]'),
+          $typeSelect = $row.find('[data-behavior=type-select]');
+
+      $typeSelect.attr('disabled', 'disabled');
+      $typeSelect.val('issue').change();
+
+      $fieldSelect.attr('disabled', 'disabled');
+      // With RTP
+      $fieldSelect.html($('<option selected></option>').attr('value', 'plugin_id').text('plugin_id'));
+      // With no RTP
+      $row.find('[data-behavior=field-label]').text('plugin_id');
+    }
+
+    function _resetRow($row) {
+      var $fieldSelect = $row.find('[data-behavior=field-select]'),
+          $typeSelect = $row.find('[data-behavior=type-select]'),
+          $fieldLabel = $row.find('[data-behavior=field-label]');
+
+      $fieldSelect.removeAttr('disabled');
+      $typeSelect.removeAttr('disabled');
+
+      // With RTP
+      _setDradisFieldSelect($typeSelect);
+      // With no RTP
+      $fieldLabel.text($fieldLabel.data('header'));
+    }
+
+    function _validateNodeSelected() {
       var $validationMessage = $('[data-behavior~=node-type-validation-message]');
       $validationMessage.addClass('d-none');
 
@@ -97,35 +136,6 @@ document.addEventListener('turbolinks:load', function() {
       }
 
       return valid;
-    }
-  }
-
-  var setDradisFieldSelect = function($select) {
-    var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
-    if (rtpFields) {
-      var fields = rtpFields[$select.val()] || [],
-          $fieldSelect = $select.closest('tr').find('[data-behavior=field-select]');
-
-      if (fields.length > 0) {
-        $fieldSelect.empty();
-        fields.forEach(function(value) {
-          $fieldSelect
-            .removeAttr('disabled')
-            .append(
-              $('<option></option>')
-              .attr('value', value)
-              .text(value)
-            );
-        });
-      } else {
-        $fieldSelect
-          .attr('disabled', 'disabled')
-          .html(
-            $('<option selected></option>')
-            .attr('value', '')
-            .text('N/A')
-          );
-      }
     }
   }
 });

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -28,13 +28,15 @@ document.addEventListener('turbolinks:load', function() {
       $(this).parents('tr').toggleClass('issue-type', $(this).val() == 'issue');
 
       // Update fields column labels
-      var hasNoFields = $(this).val() == 'node' || $(this).val() == 'skip',
+      var nodeSelected = $(this).val() == 'node',
+          skipSelected = $(this).val() == 'skip',
           $fieldLabel = $(this).closest('tr').find('[data-behavior=field-label]');
 
-      if (hasNoFields) {
+      if (skipSelected) {
         $fieldLabel.text('N/A');
-      }
-      else {
+      } else if (nodeSelected) {
+        $fieldLabel.text('Label');
+      } else {
         var header = $fieldLabel.data('header');
         $fieldLabel.text(header);
       }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -112,16 +112,20 @@ document.addEventListener('turbolinks:load', function() {
         fields.forEach(function(value) {
           $fieldSelect
             .removeAttr('disabled')
-            .append($('<option></option>')
-            .attr('value', value)
-            .text(value));
+            .append(
+              $('<option></option>')
+              .attr('value', value)
+              .text(value)
+            );
         });
       } else {
         $fieldSelect
           .attr('disabled', 'disabled')
-          .html($('<option selected></option>')
-          .attr('value', '')
-          .text('N/A'));
+          .html(
+            $('<option selected></option>')
+            .attr('value', '')
+            .text('N/A')
+          );
       }
     }
   }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -67,27 +67,34 @@ document.addEventListener('turbolinks:load', function() {
     function _setDradisFieldSelect($select) {
       var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
       if (rtpFields) {
-        var fields = rtpFields[$select.val()] || [],
+        var fields = rtpFields[$select.val()],
             $fieldSelect = $select.closest('tr').find('[data-behavior=field-select]');
 
-        if (fields.length > 0) {
-          $fieldSelect.empty();
-          fields.forEach(function(value) {
+        if ($select.val() in rtpFields){
+          if (fields.length > 0) {
+            $fieldSelect.empty();
+            fields.forEach(function(value) {
+              $fieldSelect
+                .removeAttr('disabled')
+                .append(
+                  $('<option></option>').attr('value', value).text(value)
+                );
+            });
+          }
+          else {
+            var header = $fieldSelect.data('header');
             $fieldSelect
-              .removeAttr('disabled')
-              .append(
-                $('<option></option>')
-                .attr('value', value)
-                .text(value)
+              .attr('disabled', 'disabled')
+              .html(
+                $('<option></option>').attr('value', '').text(header)
               );
-          });
-        } else {
+          }
+        }
+        else {
           $fieldSelect
             .attr('disabled', 'disabled')
             .html(
-              $('<option selected></option>')
-              .attr('value', '')
-              .text('N/A')
+              $('<option></option>').attr('value', '').text('N/A')
             );
         }
       }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -92,8 +92,13 @@ document.addEventListener('turbolinks:load', function() {
                 $('<option disabled="disabled" selected></option>').attr('value', header).text(header)
               );
           }
-        }
-        else {
+        } else if ($select.val()== 'node') { 
+          $fieldSelect
+            .attr('disabled', 'disabled')
+            .html(
+              $('<option></option>').attr('value', '').text('Label')
+            );
+        } else {
           $fieldSelect
             .attr('disabled', 'disabled')
             .html(

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -86,9 +86,8 @@ document.addEventListener('turbolinks:load', function() {
           else {
             var header = $fieldSelect.data('header');
             $fieldSelect
-              .attr('disabled', 'disabled')
               .html(
-                $('<option></option>').attr('value', '').text(header)
+                $('<option disabled="disabled" selected></option>').attr('value', header).text(header)
               );
           }
         }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -15,58 +15,57 @@ window.addEventListener('job-done', function(e){
 
 document.addEventListener('turbolinks:load', function() {
   if ($('body.upload.new').length) {
-    $('[data-behavior=type-select]').on('change', function(e) {
+    $('[data-behavior=type-select]').on('change', function() {
       var $nodeSelect = $('select option[value="node"]:selected').parent();
 
       // Disable Node Label option
-      $('[data-behavior=type-select]').each(function(i, select) {
-        var $tr = $(select).closest('tr');
-        if ($nodeSelect.length && !$nodeSelect.is($(select))) {
-          $(select).find('option[value="node"]').attr('disabled', 'disabled');
-        } else {
-          $(select).find('option[value="node"]').removeAttr('disabled');
-        }
-      });
+      if ($nodeSelect.length) {
+        $('[data-behavior=type-select]').not($nodeSelect).find('option[value="node"]').attr('disabled', 'disabled');
+      } else {
+        $('[data-behavior=type-select]').find('option[value="node"]').removeAttr('disabled');
+      }
 
       // Update fields column labels
-      var hasNoFields = $(e.target).val() == 'skip' || $(e.target).val() == 'node';
+      var hasNoFields = $(this).val() == 'node' || $(this).val() == 'skip',
+          $fieldLabel = $(this).closest('tr').find('[data-behavior=field-label]');
+
       if (hasNoFields) {
-        $(e.target).closest('tr').find('[data-behavior=field-label]').text('N/A');
+        $fieldLabel.text('N/A');
       }
       else {
-        var header = $(e.target).closest('tr').find('td:nth-child(2)').text();
-        $(e.target).closest('tr').find('[data-behavior=field-label]').text(header);
+        var header = $fieldLabel.data('header');
+        $fieldLabel.text(header);
       }
 
-
-      setDradisFieldSelect($(e.target));
+      setDradisFieldSelect($(this));
     });
 
     $('[data-behavior=identifier]').on('mousedown', function(e){
-      var $fieldSelect = $(e.target).closest('tr').find('[data-behavior=field-select]'),
-          $typeSelect = $(e.target).closest('tr').find('[data-behavior=type-select]');
+      var $currentRow = $(this).closest('tr'),
+          $fieldSelect = $currentRow.find('[data-behavior=field-select]'),
+          $typeSelect = $currentRow.find('[data-behavior=type-select]');
+
+      $typeSelect.attr('disabled', 'disabled');
+      $typeSelect.val('issue').change();
 
       $fieldSelect.attr('disabled', 'disabled');
       // With RTP
       $fieldSelect.html($('<option selected></option>').attr('value', 'plugin_id').text('plugin_id'));
       // With no RTP
-      $(e.target).closest('tr').find('[data-behavior=field-label]').text('plugin_id');
+      $currentRow.find('[data-behavior=field-label]').text('plugin_id');
 
-      $typeSelect.attr('disabled', 'disabled');
-      $typeSelect.val('issue').change();
-
-      var $prevIdentifier = $('[data-behavior=identifier]:checked'),
-          $prevFieldSelect = $prevIdentifier.closest('tr').find('[data-behavior=field-select]'),
-          $prevTypeSelect = $prevIdentifier.closest('tr').find('[data-behavior=type-select]');
+      var $prevRow = $('[data-behavior=identifier]:checked').closest('tr');
+          $prevFieldSelect = $prevRow.find('[data-behavior=field-select]'),
+          $prevTypeSelect = $prevRow.find('[data-behavior=type-select]');
 
       $prevFieldSelect.removeAttr('disabled');
+      $prevTypeSelect.removeAttr('disabled');
 
-      $prevTypeSelect.removeAttr('disabled')
       // With RTP
       setDradisFieldSelect($prevTypeSelect);
       // With no RTP
-      var header = $prevIdentifier.closest('tr').find('td:nth-child(2)').text();
-      $prevIdentifier.closest('tr').find('[data-behavior=field-label]').text(header);
+      var header = $prevRow.find('[data-behavior=field-label]').data('header');
+      $prevRow.find('[data-behavior=field-label]').text(header);
     });
 
     $('[data-behavior~=mapping-form]').submit(function() {

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -18,7 +18,7 @@ document.addEventListener('turbolinks:load', function() {
     $('[data-behavior=type-select]').on('change', function(e) {
       var $nodeSelect = $('select option[value="node"]:selected').parent();
 
-      // Disable Node Label option and update fields column labels
+      // Disable Node Label option
       $('[data-behavior=type-select]').each(function(i, select) {
         var $tr = $(select).closest('tr');
         if ($nodeSelect.length && !$nodeSelect.is($(select))) {
@@ -28,11 +28,45 @@ document.addEventListener('turbolinks:load', function() {
         }
       });
 
+      // Update fields column labels
       var hasNoFields = $(e.target).val() == 'skip' || $(e.target).val() == 'node';
-      $(e.target).closest('tr').find('[data-behavior=na-field-label]').toggleClass('d-none', !hasNoFields);
-      $(e.target).closest('tr').find('[data-behavior=default-field-label]').toggleClass('d-none', hasNoFields);
+      if (hasNoFields) {
+        $(e.target).closest('tr').find('[data-behavior=field-label]').text('N/A');
+      }
+      else {
+        var header = $(e.target).closest('tr').find('td:nth-child(2)').text();
+        $(e.target).closest('tr').find('[data-behavior=field-label]').text(header);
+      }
+
 
       setDradisFieldSelect($(e.target));
+    });
+
+    $('[data-behavior=identifier]').on('mousedown', function(e){
+      var $fieldSelect = $(e.target).closest('tr').find('[data-behavior=field-select]'),
+          $typeSelect = $(e.target).closest('tr').find('[data-behavior=type-select]');
+
+      $fieldSelect.attr('disabled', 'disabled');
+      // With RTP
+      $fieldSelect.html($('<option selected></option>').attr('value', 'plugin_id').text('plugin_id'));
+      // With no RTP
+      $(e.target).closest('tr').find('[data-behavior=field-label]').text('plugin_id');
+
+      $typeSelect.attr('disabled', 'disabled');
+      $typeSelect.val('issue');
+
+      var $prevIdentifier = $('[data-behavior=identifier]:checked'),
+          $prevFieldSelect = $prevIdentifier.closest('tr').find('[data-behavior=field-select]'),
+          $prevTypeSelect = $prevIdentifier.closest('tr').find('[data-behavior=type-select]');
+
+      $prevFieldSelect.removeAttr('disabled');
+
+      $prevTypeSelect.removeAttr('disabled')
+      // With RTP
+      setDradisFieldSelect($prevTypeSelect);
+      // With no RTP
+      var header = $prevIdentifier.closest('tr').find('td:nth-child(2)').text();
+      $prevIdentifier.closest('tr').find('[data-behavior=field-label]').text(header);
     });
 
     $('[data-behavior~=mapping-form]').on('ajax:before', function() {

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -34,22 +34,7 @@ document.addEventListener('turbolinks:load', function() {
       $nodeSelect.closest('tr').find('[data-behavior=na-field-label]').removeClass('d-none');
       $nodeSelect.closest('tr').find('[data-behavior=default-field-label]').addClass('d-none');
 
-      // Update the field select with the one from the RTP
-      var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
-      if (rtpFields) {
-        var fields = rtpFields[$(e.target).val()] || [],
-            $fieldSelect = $(e.target).closest('tr').find('[data-behavior=field-select]');
-
-        if (fields.length > 0) {
-          $fieldSelect.empty();
-          fields.forEach(function(value) {
-            $fieldSelect.append($('<option></option>').attr('value', value).text(value));
-          });
-        }
-        else {
-          $fieldSelect.html($('<option disabled="disabled" selected></option>').attr('value', '').text('N/A'));
-        }
-      }
+      setDradisFieldSelect($(e.target));
     });
 
     $('[data-behavior~=mapping-form]').on('ajax:before', function() {
@@ -64,5 +49,23 @@ document.addEventListener('turbolinks:load', function() {
       ConsoleUpdater.parsing = true;
       setTimeout(ConsoleUpdater.updateConsole, 1000);
     });
+  }
+
+  var setDradisFieldSelect = function($select) {
+    var rtpFields = $('[data-behavior=dradis-datatable]').data('rtp-fields');
+    if (rtpFields) {
+      var fields = rtpFields[$select.val()] || [],
+          $fieldSelect = $select.closest('tr').find('[data-behavior=field-select]');
+
+      if (fields.length > 0) {
+        $fieldSelect.empty();
+        fields.forEach(function(value) {
+          $fieldSelect.append($('<option></option>').attr('value', value).text(value));
+        });
+      }
+      else {
+        $fieldSelect.html($('<option disabled="disabled" selected></option>').attr('value', '').text('N/A'));
+      }
+    }
   }
 });

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -110,11 +110,18 @@ document.addEventListener('turbolinks:load', function() {
       if (fields.length > 0) {
         $fieldSelect.empty();
         fields.forEach(function(value) {
-          $fieldSelect.append($('<option></option>').attr('value', value).text(value));
+          $fieldSelect
+            .removeAttr('disabled')
+            .append($('<option></option>')
+            .attr('value', value)
+            .text(value));
         });
-      }
-      else {
-        $fieldSelect.html($('<option disabled="disabled" selected></option>').attr('value', '').text('N/A'));
+      } else {
+        $fieldSelect
+          .attr('disabled', 'disabled')
+          .html($('<option selected></option>')
+          .attr('value', '')
+          .text('N/A'));
       }
     }
   }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -53,7 +53,7 @@ document.addEventListener('turbolinks:load', function() {
       $(e.target).closest('tr').find('[data-behavior=field-label]').text('plugin_id');
 
       $typeSelect.attr('disabled', 'disabled');
-      $typeSelect.val('issue');
+      $typeSelect.val('issue').change();
 
       var $prevIdentifier = $('[data-behavior=identifier]:checked'),
           $prevFieldSelect = $prevIdentifier.closest('tr').find('[data-behavior=field-select]'),

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -25,6 +25,8 @@ document.addEventListener('turbolinks:load', function() {
         $('[data-behavior=type-select]').find('option[value="node"]').removeAttr('disabled');
       }
 
+      $(this).parents('tr').toggleClass('issue-type', $(this).val() == 'issue');
+
       // Update fields column labels
       var hasNoFields = $(this).val() == 'node' || $(this).val() == 'skip',
           $fieldLabel = $(this).closest('tr').find('[data-behavior=field-label]');

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -21,18 +21,16 @@ document.addEventListener('turbolinks:load', function() {
       // Disable Node Label option and update fields column labels
       $('[data-behavior=type-select]').each(function(i, select) {
         var $tr = $(select).closest('tr');
-
-        $tr.find('[data-behavior=na-field-label]').addClass('d-none');
-        $tr.find('[data-behavior=default-field-label]').removeClass('d-none');
-
         if ($nodeSelect.length && !$nodeSelect.is($(select))) {
           $(select).find('option[value="node"]').attr('disabled', 'disabled');
         } else {
           $(select).find('option[value="node"]').removeAttr('disabled');
         }
       });
-      $nodeSelect.closest('tr').find('[data-behavior=na-field-label]').removeClass('d-none');
-      $nodeSelect.closest('tr').find('[data-behavior=default-field-label]').addClass('d-none');
+
+      var hasNoFields = $(e.target).val() == 'skip' || $(e.target).val() == 'node';
+      $(e.target).closest('tr').find('[data-behavior=na-field-label]').toggleClass('d-none', !hasNoFields);
+      $(e.target).closest('tr').find('[data-behavior=default-field-label]').toggleClass('d-none', hasNoFields);
 
       setDradisFieldSelect($(e.target));
     });

--- a/app/assets/stylesheets/dradis/plugins/csv/upload.scss
+++ b/app/assets/stylesheets/dradis/plugins/csv/upload.scss
@@ -9,9 +9,32 @@ body.upload.new {
 
   .table {
     margin-bottom: 0 !important;
-    
-    td {
-      vertical-align: middle;
+
+    tr {
+      &.issue-type:hover {
+        .identifier {
+          opacity: 1;
+          pointer-events: all;
+        }
+      }
+
+      td {
+        vertical-align: middle;
+
+        &:first-child {
+          padding-left: 1.25rem;
+          width: 3rem;
+        }
+
+        .identifier {
+          opacity: 0;
+          pointer-events: none;
+
+          &:checked {
+            opacity: 1;
+          }
+        }
+      }
     }
   }
 

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -6,7 +6,7 @@ module Dradis::Plugins::CSV
     before_action :load_rtp_fields, only: [:new]
 
     def new
-      @default_columns = ['Unique Identifier', 'Column Header From File', 'Type', 'Field in Dradis']
+      @default_columns = ['ID', 'Column Header From File', 'Type', 'Field in Dradis']
       @headers = ::CSV.open(@attachment.fullpath, &:readline)
 
       @log_uid = Log.new.uid

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -6,7 +6,7 @@ module Dradis::Plugins::CSV
     before_action :load_rtp_fields, only: [:new]
 
     def new
-      @default_columns = ['ID', 'Column Header From File', 'Type', 'Field in Dradis']
+      @default_columns = ['ID', 'Column Header', 'Entity', 'Dradis Field']
       @headers = ::CSV.open(@attachment.fullpath, &:readline)
 
       @log_uid = Log.new.uid

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -3,10 +3,10 @@ module Dradis::Plugins::CSV
     include ProjectScoped
 
     before_action :load_attachment, only: [:new]
+    before_action :load_rtp_fields, only: [:new]
 
     def new
       @default_columns = ['Unique Identifier', 'Column Header From File', 'Type', 'Field in Dradis']
-
       @headers = ::CSV.open(@attachment.fullpath, &:readline)
     end
 
@@ -15,6 +15,17 @@ module Dradis::Plugins::CSV
     end
 
     private
+
+    def load_rtp_fields
+      rtp = current_project.report_template_properties
+      @rtp_fields =
+        unless rtp.nil?
+          {
+            evidence: rtp.evidence_fields.map(&:name),
+            issue: rtp.issue_fields.map(&:name)
+          }
+        end
+    end
 
     def load_attachment
       job_id = params[:job_id].to_i

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -32,7 +32,6 @@
       data-default-columns="<%= @default_columns %>"
       data-item-name="csv_item"
       data-paging="false"
-      data-rtp-fields="<%= @rtp_fields.to_json %>"
     >
       <thead>
         <tr>
@@ -53,8 +52,13 @@
             <td>
               <% if @rtp_fields %>
                 <div class="form-group m-0">
-                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, header]], disabled: header, selected: header) %>
-                  <%= f.select "mappings[field_attributes][#{index}][field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select', header: header } %>
+                  <% issue_options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, header]], disabled: header, selected: header) %>
+                  <%= f.select "mappings[field_attributes][#{index}][field]", issue_options, {}, class: 'form-control custom-select w-75 field-select', data: { behavior: 'issue-field-select', header: header } %>
+
+                  <% evidence_options = @rtp_fields[:evidence].any? ? options_for_select(@rtp_fields[:evidence]) : options_for_select([[header, header]], disabled: header, selected: header) %>
+                  <%= f.select "mappings[field_attributes][#{index}][field]", evidence_options, {}, disabled: true, class: 'form-control custom-select w-75 field-select d-none', data: { behavior: 'evidence-field-select', header: header } %>
+
+                  <%= f.select "mappings[field_attributes][#{index}][field]", [['N/A', '']], {}, disabled: true, class: 'form-control custom-select w-75 field-select d-none', data: { behavior: 'empty-field-select', header: header } %>
                 </div>
               <% else %>
                 <span data-behavior="field-label" data-header="<%= header %>" ><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -57,7 +57,7 @@
               <% if @rtp_fields %>
                 <div class="form-group m-0">
                   <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([['N/A', '']], disabled: '', selected: '') %>
-                  <%= f.select "mappings[#{index}[field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
+                  <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
                 </div>
               <% else %>
                 <span data-behavior="field-label"><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -30,7 +30,7 @@
     >
       <thead>
         <tr>
-          <th class="no-sort">Unique Identifier <i class="fa fa-question-circle" data-toggle="tooltip" title="Ensure duplicate issues with this value are not created."></i></th>
+          <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Set this field as a unique id to prevent creating duplicate issues with the same value for this field."></i></th>
           <th>Column Header From File</th>
           <th class="no-sort">Type</th>
           <th>Field in Dradis</th>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -50,7 +50,7 @@
             <td><%= header %></td>
             <td>
               <div class="form-group m-0">
-                <%= f.select "mappings[field_attributes][#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node Label', 'node'], ['&#9472;'.html_safe, 'divider'], ['Do Not Import','skip']], { disabled: 'divider' }, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
+                <%= f.select "mappings[field_attributes][#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node', 'node'], ['&#9472;'.html_safe, 'divider'], ['Do Not Import','skip']], { disabled: 'divider' }, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
               </div>
             </td>
             <td>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -56,8 +56,8 @@
             <td>
               <% if @rtp_fields %>
                 <div class="form-group m-0">
-                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([['N/A', '']], disabled: '', selected: '') %>
-                  <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
+                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, '']]) %>
+                  <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', disabled: @rtp_fields[:issue].empty?, data: { behavior: 'field-select', header: header } %>
                 </div>
               <% else %>
                 <span data-behavior="field-label" data-header="<%= header %>" ><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -30,7 +30,7 @@
     >
       <thead>
         <tr>
-          <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Set this field as a unique id to prevent creating duplicate issues with the same value for this field."></i></th>
+          <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Set this field as a unique id. This will prevent importing duplicate issues that have the same value for this field."></i></th>
           <th>Column Header</th>
           <th class="no-sort">Entity</th>
           <th>Dradis Field</th>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -38,10 +38,10 @@
       </thead>
       <tbody>
         <% @headers.each_with_index do |header, index| %>
-          <tr>
+          <tr class="issue-type">
             <td>
               <div class="form-check">
-                <%= f.radio_button 'identifier', index, class: 'form-check-input', data: { behavior: 'identifier' }, required: true %>
+                <%= f.radio_button 'identifier', index, class: 'form-check-input identifier', data: { behavior: 'identifier' }, required: true %>
                 <%= f.label :identifier, class: 'form-check-label' do %>
                   <span class="sr-only">Select</span>
                 <% end %>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -19,6 +19,7 @@
       data-default-columns="<%= @default_columns %>"
       data-item-name="csv_item"
       data-paging="false"
+      data-rtp-fields="<%= @rtp_fields.to_json %>"
     >
       <thead>
         <tr>
@@ -46,9 +47,9 @@
                   </div>
                 </td>
                 <td>
-                  <% if current_project.report_template_properties %>
+                  <% if @rtp_fields %>
                     <div class="form-group m-0">
-                      <%= f.text_field "mappings[#{index}][field]", class: 'form-control' %>
+                      <%= f.select "mappings[#{index}[field]", options_for_select(@rtp_fields[:issue]), {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
                     </div>
                   <% else %>
                     <span data-behavior="default-field-label"><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -46,7 +46,7 @@
             <td><%= header %></td>
             <td>
               <div class="form-group m-0">
-                <%= f.select "mappings[#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node Label', 'node']], {}, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
+                <%= f.select "mappings[#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node Label', 'node'], ['Do not import','skip']], {}, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
               </div>
             </td>
             <td>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -31,9 +31,9 @@
       <thead>
         <tr>
           <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Set this field as a unique id to prevent creating duplicate issues with the same value for this field."></i></th>
-          <th>Column Header From File</th>
-          <th class="no-sort">Type</th>
-          <th>Field in Dradis</th>
+          <th>Column Header</th>
+          <th class="no-sort">Entity</th>
+          <th>Dradis Field</th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -50,7 +50,7 @@
             <td><%= header %></td>
             <td>
               <div class="form-group m-0">
-                <%= f.select "mappings[#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node Label', 'node'], ['Do not import','skip']], {}, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
+                <%= f.select "mappings[#{index}][type]", [['Issue Field', 'issue'], ['Evidence Field', 'evidence'], ['Node Label', 'node'], ['&#9472;'.html_safe, 'divider'], ['Do Not Import','skip']], { disabled: 'divider' }, class: 'form-control custom-select w-75', data: { behavior: 'type-select' } %>
               </div>
             </td>
             <td>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -30,7 +30,7 @@
     >
       <thead>
         <tr>
-          <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Set this field as a unique id. This will prevent importing duplicate issues that have the same value for this field."></i></th>
+          <th class="no-sort">ID <i class="fa fa-question-circle" data-toggle="tooltip" title="Use to deduplicate records"></i></th>
           <th>Column Header</th>
           <th class="no-sort">Entity</th>
           <th>Dradis Field</th>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -50,9 +50,10 @@
               </div>
             </td>
             <td>
-              <% if current_project.report_template_properties %>
+              <% if @rtp_fields %>
                 <div class="form-group m-0">
-                  <%= f.text_field "mappings[#{index}][field]", class: 'form-control' %>
+                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([['N/A', '']], disabled: '', selected: '') %>
+                  <%= f.select "mappings[#{index}[field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
                 </div>
               <% else %>
                 <span data-behavior="default-field-label"><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -66,8 +66,7 @@
                   <%= f.select "mappings[#{index}[field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
                 </div>
               <% else %>
-                <span data-behavior="default-field-label"><%= header %></span>
-                <span data-behavior="na-field-label" class="d-none">N/A</span>
+                <span data-behavior="field-label"><%= header %></span>
               <% end %>
             </td>
           </tr>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -56,8 +56,8 @@
             <td>
               <% if @rtp_fields %>
                 <div class="form-group m-0">
-                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, '']]) %>
-                  <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', disabled: @rtp_fields[:issue].empty?, data: { behavior: 'field-select', header: header } %>
+                  <% options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, header]], disabled: header, selected: header) %>
+                  <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select', header: header } %>
                 </div>
               <% else %>
                 <span data-behavior="field-label" data-header="<%= header %>" ><%= header %></span>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -60,7 +60,7 @@
                   <%= f.select "mappings[#{index}][field]", options, {}, class: 'form-control custom-select w-75', data: { behavior: 'field-select' } %>
                 </div>
               <% else %>
-                <span data-behavior="field-label"><%= header %></span>
+                <span data-behavior="field-label" data-header="<%= header %>" ><%= header %></span>
               <% end %>
             </td>
           </tr>

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -58,7 +58,7 @@ describe 'upload feature', js: true do
           end
 
           click_button 'Import CSV'
-          expect(page).to have_text('A Node Label Type must be selected to import evidence records.')
+          expect(page).to have_text('A Node Label must be selected to import evidence records.')
         end
       end
 

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -12,6 +12,8 @@ describe 'upload feature', js: true do
   context 'uploading a CSV file' do
     let(:file_path) { File.expand_path('../fixtures/files/simple.csv', __dir__) }
     before do
+      @headers = CSV.open(file_path, &:readline)
+
       select 'Dradis::Plugins::CSV', from: 'uploader'
 
       within('.custom-file') do
@@ -26,10 +28,8 @@ describe 'upload feature', js: true do
     end
 
     it 'lists the fields in the table' do
-      headers = CSV.open(file_path, &:readline)
-
       within('tbody') do
-        headers.each do |header|
+        @headers.each do |header|
           expect(page).to have_selector('td', text: header)
         end
       end
@@ -40,14 +40,14 @@ describe 'upload feature', js: true do
         it 'shows a validation message on the page' do
           click_button 'Import CSV'
 
-          message = page.find('#identifier_0').native.attribute('validationMessage')
+          message = page.find('#identifier_0', visible: false).native.attribute('validationMessage')
           expect(message).to eq('Please select one of these options.')
         end
       end
 
       context 'when there are evidence type but no node type selected' do
         it 'shows a validation message on the page' do
-          # Select identifer column
+          all('tbody tr')[0].hover
           find('#identifier_0').click
 
           within all('tbody tr')[4] do
@@ -61,20 +61,12 @@ describe 'upload feature', js: true do
 
       context 'when project does not have RTP' do
         it 'imports all columns as fields' do
-          # Select identifer column
+          all('tbody tr')[0].hover
           find('#identifier_0').click
 
-          within all('tbody tr')[3] do
-            select 'Node Label'
-          end
-
-          within all('tbody tr')[4] do
-            select 'Evidence Field'
-          end
-
-          within all('tbody tr')[5] do
-            select 'Evidence Field'
-          end
+          select 'Node Label', from: 'mappings[3][type]'
+          select 'Evidence Field', from: 'mappings[4][type]'
+          select 'Evidence Field', from: 'mappings[5][type]'
 
           perform_enqueued_jobs do
             click_button 'Import CSV'
@@ -97,81 +89,119 @@ describe 'upload feature', js: true do
 
       context 'when project have RTP' do
         before do
-          @evidence_fields = [
-            { name: 'Location', type: :string, default: true },
-            { name: 'Port', type: :string, default: true}
-          ]
-          @issue_fields = [
-            { name: 'Title', type: :string, default: true },
-            { name: 'Description', type: :string, default: true}
-          ]
-
-          rtp = create(:report_template_properties, evidence_fields: @evidence_fields, issue_fields: @issue_fields)
-
+          rtp = create(:report_template_properties, evidence_fields: evidence_fields, issue_fields: issue_fields)
           @project.update(report_template_properties: rtp)
 
           page.refresh
+
+          all('tbody tr')[0].hover
+          find('#identifier_0').click
         end
 
-        it 'shows the available fields for the selected type' do
-          select 'Issue Field', from: 'mappings[1][type]'
+        context 'without fields' do
+          let (:evidence_fields) { [] }
+          let (:issue_fields) { [] }
 
-          within all('tbody tr')[1] do
-            @issue_fields.each do |field|
-              expect(page).to have_selector('option', text: field[:name])
+          it 'creates records with fields from the headers' do
+            select 'Node Label', from: 'mappings[3][type]'
+            select 'Evidence Field', from: 'mappings[4][type]'
+            within all('tbody tr')[4] do
+              expect(page).to have_selector('option', text: 'Location')
+            end
+
+            select 'Evidence Field', from: 'mappings[5][type]'
+            within all('tbody tr')[5] do
+              expect(page).to have_selector('option', text: 'Port')
+            end
+
+            perform_enqueued_jobs do
+              click_button 'Import CSV'
+
+              find('#console .log', wait: 30, match: :first)
+
+              expect(page).to have_text('Worker process completed.')
+
+              issue = Issue.last
+              expect(issue.fields).to eq({ 'Description' => 'Test CSV', 'Title' => 'SQL Injection', 'plugin' => 'csv', 'plugin_id' => '1' })
+
+              node = issue.affected.first
+              expect(node.label).to eq('10.0.0.1')
+
+              evidence = node.evidence.first
+              expect(evidence.fields).to eq({ 'Label' => '10.0.0.1', 'Location' => '10.0.0.1', 'Title' => 'SQL Injection', 'Port' => '443' })
+            end
+          end
+        end
+
+        context 'with fields' do
+          let (:evidence_fields) {
+            [
+              { name: 'Location', type: :string, default: true },
+              { name: 'Port', type: :string, default: true}
+            ]
+          }
+
+          let (:issue_fields) {
+            [
+              { name: 'Title', type: :string, default: true },
+              { name: 'Description', type: :string, default: true}
+            ]
+          }
+
+          it 'shows the available fields for the selected type' do
+            select 'Issue Field', from: 'mappings[1][type]'
+
+            within all('tbody tr')[1] do
+              issue_fields.each do |field|
+                expect(page).to have_selector('option', text: field[:name])
+              end
+            end
+
+            select 'Evidence Field', from: 'mappings[4][type]'
+
+            within all('tbody tr')[4] do
+              evidence_fields.each do |field|
+                expect(page).to have_selector('option', text: field[:name])
+              end
             end
           end
 
-          select 'Evidence Field', from: 'mappings[4][type]'
-
-          within all('tbody tr')[4] do
-            @evidence_fields.each do |field|
-              expect(page).to have_selector('option', text: field[:name])
-            end
+          it 'auto-selects the type and field for the identifier' do
+            expect(page).to have_select('mappings[0][type]', selected: 'Issue Field', disabled: true)
+            expect(page).to have_select('mappings[0][field]', selected: 'plugin_id', disabled: true)
           end
-        end
 
-        it 'auto-selects the type and field for the identifier' do
-          # Select identifer column
-          find('#identifier_0').click
+          it 'can select which columns to import' do
+            select 'Issue Field', from: 'mappings[1][type]'
+            select 'Title', from: 'mappings[1][field]'
 
-          expect(page).to have_select('mappings[0][type]', selected: 'Issue Field', disabled: true)
-          expect(page).to have_select('mappings[0][field]', selected: 'plugin_id', disabled: true)
-        end
+            select 'Issue Field', from: 'mappings[2][type]'
+            select 'Description', from: 'mappings[2][field]'
 
-        it 'can select which columns to import' do
-          # Select identifer column
-          find('#identifier_0').click
+            select 'Node Label', from: 'mappings[3][type]'
 
-          select 'Issue Field', from: 'mappings[1][type]'
-          select 'Title', from: 'mappings[1][field]'
+            select 'Evidence Field', from: 'mappings[4][type]'
+            select 'Location', from: 'mappings[4][field]'
 
-          select 'Issue Field', from: 'mappings[2][type]'
-          select 'Description', from: 'mappings[2][field]'
+            select 'Evidence Field', from: 'mappings[5][type]'
+            select 'Port', from: 'mappings[5][field]'
 
-          select 'Node Label', from: 'mappings[3][type]'
+            perform_enqueued_jobs do
+              click_button 'Import CSV'
 
-          select 'Evidence Field', from: 'mappings[4][type]'
-          select 'Location', from: 'mappings[4][field]'
+              find('#console .log', wait: 30, match: :first)
 
-          select 'Evidence Field', from: 'mappings[5][type]'
-          select 'Port', from: 'mappings[5][field]'
+              expect(page).to have_text('Worker process completed.')
 
-          perform_enqueued_jobs do
-            click_button 'Import CSV'
+              issue = Issue.last
+              expect(issue.fields).to eq({ 'Description' => 'Test CSV', 'Title' => 'SQL Injection', 'plugin' => 'csv', 'plugin_id' => '1' })
 
-            find('#console .log', wait: 30, match: :first)
+              node = issue.affected.first
+              expect(node.label).to eq('10.0.0.1')
 
-            expect(page).to have_text('Worker process completed.')
-
-            issue = Issue.last
-            expect(issue.fields).to eq({ 'Description' => 'Test CSV', 'Title' => 'SQL Injection', 'plugin' => 'csv', 'plugin_id' => '1' })
-
-            node = issue.affected.first
-            expect(node.label).to eq('10.0.0.1')
-
-            evidence = node.evidence.first
-            expect(evidence.fields).to eq({ 'Label' => '10.0.0.1', 'Location' => '10.0.0.1', 'Title' => 'SQL Injection', 'Port' => '443' })
+              evidence = node.evidence.first
+              expect(evidence.fields).to eq({ 'Label' => '10.0.0.1', 'Location' => '10.0.0.1', 'Title' => 'SQL Injection', 'Port' => '443' })
+            end
           end
         end
       end

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -64,9 +64,9 @@ describe 'upload feature', js: true do
           all('tbody tr')[0].hover
           find('#identifier_0').click
 
-          select 'Node Label', from: 'mappings[3][type]'
-          select 'Evidence Field', from: 'mappings[4][type]'
-          select 'Evidence Field', from: 'mappings[5][type]'
+          select 'Node', from: 'mappings[field_attributes][3][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][5][type]'
 
           perform_enqueued_jobs do
             click_button 'Import CSV'
@@ -103,13 +103,13 @@ describe 'upload feature', js: true do
           let (:issue_fields) { [] }
 
           it 'creates records with fields from the headers' do
-            select 'Node Label', from: 'mappings[3][type]'
-            select 'Evidence Field', from: 'mappings[4][type]'
+            select 'Node', from: 'mappings[field_attributes][3][type]'
+            select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
             within all('tbody tr')[4] do
               expect(page).to have_selector('option', text: 'Location')
             end
 
-            select 'Evidence Field', from: 'mappings[5][type]'
+            select 'Evidence Field', from: 'mappings[field_attributes][5][type]'
             within all('tbody tr')[5] do
               expect(page).to have_selector('option', text: 'Port')
             end
@@ -149,7 +149,7 @@ describe 'upload feature', js: true do
           }
 
           it 'shows the available fields for the selected type' do
-            select 'Issue Field', from: 'mappings[1][type]'
+            select 'Issue Field', from: 'mappings[field_attributes][1][type]'
 
             within all('tbody tr')[1] do
               issue_fields.each do |field|
@@ -157,7 +157,7 @@ describe 'upload feature', js: true do
               end
             end
 
-            select 'Evidence Field', from: 'mappings[4][type]'
+            select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
 
             within all('tbody tr')[4] do
               evidence_fields.each do |field|
@@ -167,24 +167,24 @@ describe 'upload feature', js: true do
           end
 
           it 'auto-selects the type and field for the identifier' do
-            expect(page).to have_select('mappings[0][type]', selected: 'Issue Field', disabled: true)
-            expect(page).to have_select('mappings[0][field]', selected: 'plugin_id', disabled: true)
+            expect(page).to have_select('mappings[field_attributes][0][type]', selected: 'Issue Field', disabled: true)
+            expect(page).to have_select('mappings[field_attributes][0][field]', selected: 'plugin_id', disabled: true)
           end
 
           it 'can select which columns to import' do
-            select 'Issue Field', from: 'mappings[1][type]'
-            select 'Title', from: 'mappings[1][field]'
+            select 'Issue Field', from: 'mappings[field_attributes][1][type]'
+            select 'Title', from: 'mappings[field_attributes][1][field]'
 
-            select 'Issue Field', from: 'mappings[2][type]'
-            select 'Description', from: 'mappings[2][field]'
+            select 'Issue Field', from: 'mappings[field_attributes][2][type]'
+            select 'Description', from: 'mappings[field_attributes][2][field]'
 
-            select 'Node Label', from: 'mappings[3][type]'
+            select 'Node', from: 'mappings[field_attributes][3][type]'
 
-            select 'Evidence Field', from: 'mappings[4][type]'
-            select 'Location', from: 'mappings[4][field]'
+            select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
+            select 'Location', from: 'mappings[field_attributes][4][field]'
 
-            select 'Evidence Field', from: 'mappings[5][type]'
-            select 'Port', from: 'mappings[5][field]'
+            select 'Evidence Field', from: 'mappings[field_attributes][5][type]'
+            select 'Port', from: 'mappings[field_attributes][5][field]'
 
             perform_enqueued_jobs do
               click_button 'Import CSV'


### PR DESCRIPTION
### Spec
When a user uploads a CSV file and the project has an RTP associated with it with issue/evidence fields, we need to give the user the ability to select which fields in the RTP to import the CSV fields to.

**Proposed solution**
Add a column in the mapping view that shows the available fields from the RTP