### PR TITLE
Attachment hidden field

### DIFF
--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -6,8 +6,9 @@ window.addEventListener('job-done', function(e){
     if (uploader.value === 'Dradis::Plugins::CSV') {
       var path = window.location.pathname;
       var project_path = path.split('/').slice(0, -1).join('/');
+      var attachment = $('#filename').val();
 
-      var redirectPath  = project_path + '/addons/csv/upload/new?job_id=' + jobId;
+      var redirectPath  = project_path + '/addons/csv/upload/new?attachment=' + attachment;
       Turbolinks.visit(redirectPath);
     }
   }

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -1,12 +1,11 @@
-window.addEventListener('job-done', function(e){
+window.addEventListener('job-done', function(){
   if ($('body.upload.index').length) {
-    var jobId = e.detail.job_id,
-        uploader = document.getElementById('uploader');
+    var uploader = document.getElementById('uploader');
 
     if (uploader.value === 'Dradis::Plugins::CSV') {
       var path = window.location.pathname;
       var project_path = path.split('/').slice(0, -1).join('/');
-      var attachment = $('#filename').val();
+      var attachment = $('#attachment').val();
 
       var redirectPath  = project_path + '/addons/csv/upload/new?attachment=' + attachment;
       Turbolinks.visit(redirectPath);

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -17,12 +17,7 @@ module Dradis::Plugins::CSV
     private
 
     def load_attachment
-      if Integer(params[:job_id], exception: false)
-        filename = Resque.redis.get(Importer::REDIS_PREFIX + params[:job_id])
-        @attachment = Attachment.find(filename, conditions: { node_id: current_project.plugin_uploads_node.id })
-      else
-        redirect_to main_app.project_upload_path, alert: 'Something fishy is going on...'
-      end
+      @attachment = Attachment.find(params[:attachment], conditions: { node_id: current_project.plugin_uploads_node.id })
     end
   end
 end

--- a/lib/dradis/plugins/csv/importer.rb
+++ b/lib/dradis/plugins/csv/importer.rb
@@ -1,18 +1,11 @@
 module Dradis::Plugins::CSV
   class Importer < Dradis::Plugins::Upload::Importer
-    REDIS_PREFIX = 'addons-csv-upload-'.freeze
-
     def self.templates
       {}
     end
 
     def import(params={})
       logger.info { 'Uploading CSV file...' }
-
-      uid = @logger.uid
-
-      # SEE: app/controllers/dradis/plugins/csv/upload_controller.rb
-      Resque.redis.set(REDIS_PREFIX + uid.to_s, File.basename(params[:file]))
 
       logger.info { 'Done' }
     end


### PR DESCRIPTION
### Spec
Redis isn't a prior requirement before this cycle so it shouldn't be added as one for this cycle.

**Proposed solution**
Remove redis as a requirement and use the DOM to store the attachment filename