### PR TITLE
Parse the incoming filename to support names with special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.9.0 (XXX 2023)
+  - Fix CSV upload for files with special characters
+
 v4.8.0 (April 2023)
   - No changes
 

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -30,15 +30,9 @@ module Dradis::Plugins::CSV
       @job_logger ||= Log.new(uid: params[:log_uid].to_i)
     end
 
-    def load_rtp_fields
-      rtp = current_project.report_template_properties
-      @rtp_fields =
-        unless rtp.nil?
-          {
-            evidence: rtp.evidence_fields.map(&:name),
-            issue: rtp.issue_fields.map(&:name)
-          }
-        end
+    def load_attachment
+      filename = CGI::escape params[:attachment]
+      @attachment = Attachment.find(filename, conditions: { node_id: current_project.plugin_uploads_node.id })
     end
 
     def load_csv_headers
@@ -55,8 +49,15 @@ module Dradis::Plugins::CSV
       end
     end
 
-    def load_attachment
-      @attachment = Attachment.find(params[:attachment], conditions: { node_id: current_project.plugin_uploads_node.id })
+    def load_rtp_fields
+      rtp = current_project.report_template_properties
+      @rtp_fields =
+        unless rtp.nil?
+          {
+            evidence: rtp.evidence_fields.map(&:name),
+            issue: rtp.issue_fields.map(&:name)
+          }
+        end
     end
 
     def mappings_params

--- a/lib/dradis/plugins/csv/gem_version.rb
+++ b/lib/dradis/plugins/csv/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 8
+        MINOR = 9
         TINY = 0
         PRE = nil
 

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -199,12 +199,16 @@ describe 'upload feature', js: true do
           let (:issue_fields) { [] }
 
           it 'still creates evidence record' do
-            within all('tbody tr')[1] do
-              select 'Node'
+            within all('tbody tr')[0] do
+              select 'Issue ID'
             end
 
-            within all('tbody tr')[2] do
-              select 'Issue ID'
+            within all('tbody tr')[1] do
+              select 'Issue Field'
+            end
+
+            within all('tbody tr')[3] do
+              select 'Node'
             end
 
             within all('tbody tr')[5] do
@@ -233,8 +237,7 @@ describe 'upload feature', js: true do
     end
   end
 
-  context 'uploading a malformed CSV file' do
-    let(:file_path) { File.expand_path('../fixtures/files/simple_malformed.csv', __dir__) }
+  describe 'CSV file samples' do
     before do
       select 'Dradis::Plugins::CSV', from: 'uploader'
 
@@ -243,25 +246,36 @@ describe 'upload feature', js: true do
       end
     end
 
-    it 'redirects to upload manager' do
-      expect(page).to have_text('The uploaded file is not a valid CSV file')
-      expect(current_path).to eq(main_app.project_upload_manager_path(@project))
-    end
-  end
+    context 'uploading a malformed CSV file' do
+      let(:file_path) { File.expand_path('../fixtures/files/simple_malformed.csv', __dir__) }
 
-  context 'uploading any file other than CSV' do
-    let(:file_path) { Rails.root.join('spec/fixtures/files/rails.png') }
-    before do
-      select 'Dradis::Plugins::CSV', from: 'uploader'
+      it 'redirects to upload manager with error' do
+        find('.alert.alert-danger', wait: 30)
 
-      within('.custom-file') do
-        page.find('#file', visible: false).attach_file(file_path)
+        expect(page).to have_text('The uploaded file is not a valid CSV file')
+        expect(current_path).to eq(main_app.project_upload_manager_path(@project))
       end
     end
 
-    it 'redirects to upload manager' do
-      expect(page).to have_text('The uploaded file is not a CSV file.')
-      expect(current_path).to eq(main_app.project_upload_manager_path(@project))
+    context 'uploading any file other than CSV' do
+      let(:file_path) { Rails.root.join('spec/fixtures/files/rails.png') }
+
+      it 'redirects to upload manager with error' do
+        find('.alert.alert-danger', wait: 30)
+
+        expect(page).to have_text('The uploaded file is not a CSV file.')
+        expect(current_path).to eq(main_app.project_upload_manager_path(@project))
+      end
+    end
+
+    context 'uploading file with special characters in the filename' do
+      let(:file_path) { File.expand_path('../fixtures/files/simple (copy).csv', __dir__) }
+
+      it 'redirects to upload manager' do
+        find('body.upload.new', wait: 30)
+
+        expect(current_path).to eq(csv.new_project_upload_path(@project))
+      end
     end
   end
 end

--- a/spec/fixtures/files/simple (copy).csv
+++ b/spec/fixtures/files/simple (copy).csv
@@ -1,0 +1,2 @@
+"Id","Title","Description","Host","Location","Port","Vulnerability Category"
+"1","SQL Injection","Test CSV","10.0.0.1","10.0.0.1","443","High"


### PR DESCRIPTION
### Spec
Currently, uploading a CSV file with special characters results in the following error: `Could not find Attachment with filename`

This happens because the incoming filename is not escaped.

**Proposed solution**
Add the same line as we do in the [upload_controller](https://github.com/dradis/dradis-ce/blob/develop/app/controllers/upload_controller.rb#L27) that escapes the filename:
```
filename = CGI::escape params[:file].original_filename
```