### PR TITLE
Add state params when uploading CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.20.0 (Month 2026)
+  -  Fix state selection not being applied correctly
+
 v4.19.0 (November 2025)
   - No changes
 

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -3,12 +3,14 @@ window.addEventListener('job-done', function () {
     var uploader = document.getElementById('uploader');
 
     if (uploader.value === 'Dradis::Plugins::CSV') {
+      var state = document.getElementById('state').value;
       var path = window.location.pathname;
       var project_path = path.split('/').slice(0, -1).join('/');
       var attachment = $('#attachment').val();
 
+      var params = new URLSearchParams({ attachment: attachment, state: state });
       var redirectPath =
-        project_path + '/addons/csv/upload/new?attachment=' + attachment;
+        project_path + '/addons/csv/upload/new?' + params.toString();
       Turbo.visit(redirectPath);
     }
   }

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -67,7 +67,7 @@ module Dradis::Plugins::CSV
 
     def state
       @state ||=
-        Issue.states.keys.include?(params[:state]) ? params[:state] : 'draft'
+        Issue.states.key?(params[:state]) ? params[:state] : 'draft'
     end
   end
 end

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -20,6 +20,7 @@ module Dradis::Plugins::CSV
         file: @attachment.fullpath.to_s,
         mappings: mappings_params[:field_attributes].to_h,
         project_id: current_project.id,
+        state: state,
         uid: params[:log_uid].to_i
       )
     end
@@ -62,6 +63,11 @@ module Dradis::Plugins::CSV
 
     def mappings_params
       params.require(:mappings).permit(field_attributes: [:field, :type])
+    end
+
+    def state
+      @state ||=
+        Issue.states.keys.include?(params[:state]) ? params[:state] : 'draft'
     end
   end
 end

--- a/app/jobs/dradis/plugins/csv/mapping_import_job.rb
+++ b/app/jobs/dradis/plugins/csv/mapping_import_job.rb
@@ -13,7 +13,7 @@ module Dradis::Plugins::CSV
     #   '2' => { 'type' => 'identifier' },
     #   '3' => { 'type' => 'evidence', 'field' => 'Port' }
     # }
-    def perform(default_user_id:, file:, mappings:, project_id:, uid:)
+    def perform(default_user_id:, file:, mappings:, project_id:, state:, uid:)
       logger = Log.new(uid: uid)
       logger.write { "Job id is #{job_id}." }
 
@@ -21,7 +21,8 @@ module Dradis::Plugins::CSV
         default_user_id: default_user_id,
         logger: logger,
         plugin: self.class.module_parent,
-        project_id: project_id
+        project_id: project_id,
+        state: state
       )
 
       importer.import_csv(file: file, mappings: mappings)

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -26,6 +26,7 @@
     <%= hidden_field_tag 'log_uid', @log_uid %>
     <%= hidden_field_tag 'job_id', params[:job_id] %>
     <%= hidden_field_tag 'attachment', params[:attachment] %>
+    <%= hidden_field_tag 'state', params[:state] %>
 
     <table class="table table-striped mb-0">
       <thead>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -22,7 +22,7 @@
     </div>
   </div>
 
-  <%= form_with url: project_upload_index_path(current_project, format: :js), method: :post, data: { behavior: 'mapping-form' } do |f| %>
+  <%= form_with url: project_upload_index_path(current_project, format: :js), method: :post, local: false, data: { behavior: 'mapping-form' } do |f| %>
     <%= hidden_field_tag 'log_uid', @log_uid %>
     <%= hidden_field_tag 'job_id', params[:job_id] %>
     <%= hidden_field_tag 'attachment', params[:attachment] %>

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -64,7 +64,7 @@ describe 'upload feature', js: true do
         end
       end
 
-      context 'states' do
+      context 'valid states' do
         it 'imports the issues based on the selected state' do
           select 'Issue ID', from: 'mappings[field_attributes][0][type]'
           select 'Node', from: 'mappings[field_attributes][3][type]'
@@ -79,6 +79,30 @@ describe 'upload feature', js: true do
             expect(page).to have_text('Worker process completed.')
 
             expect(Issue.published.count).to eq(1)
+          end
+        end
+      end
+
+      context 'invalid states' do
+        it 'imports the issues as draft' do
+          select 'Issue ID', from: 'mappings[field_attributes][0][type]'
+          select 'Node', from: 'mappings[field_attributes][3][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][5][type]'
+
+          page.execute_script(<<~JS)
+            const select = document.querySelector('#state');
+            select.value = 'tampered_value';
+          JS
+
+          perform_enqueued_jobs do
+            click_button 'Import CSV'
+
+            find('#console .log', wait: 30, match: :first)
+
+            expect(page).to have_text('Worker process completed.')
+
+            expect(Issue.published.count).to eq(0)
           end
         end
       end

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -14,13 +14,15 @@ describe 'upload feature', js: true do
     before do
       @headers = CSV.open(file_path, &:readline)
 
-      select 'Dradis::Plugins::CSV', from: 'uploader'
+      find('#state + .combobox').click
+      find('#state ~ .combobox-menu .combobox-option', text: 'Published').click
 
-      within('.custom-file') do
-        page.find('#file', visible: false).attach_file(file_path)
-      end
+      find('#uploader + .combobox').click
+      find('#uploader ~ .combobox-menu .combobox-option', text: 'Dradis::Plugins::CSV').click
 
-      find('body.upload.new', wait: 30)
+      attach_file 'file', file_path, visible: false, disabled: false
+
+      expect(page).to have_text('CSV Upload Mapping', wait: 30)
     end
 
     it 'redirects to the mapping page' do
@@ -59,6 +61,25 @@ describe 'upload feature', js: true do
 
           click_button 'Import CSV'
           expect(page).to have_text('A Node Label must be selected to import evidence records.')
+        end
+      end
+
+      context 'states' do
+        it 'imports the issues based on the selected state' do
+          select 'Issue ID', from: 'mappings[field_attributes][0][type]'
+          select 'Node', from: 'mappings[field_attributes][3][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][4][type]'
+          select 'Evidence Field', from: 'mappings[field_attributes][5][type]'
+
+          perform_enqueued_jobs do
+            click_button 'Import CSV'
+
+            find('#console .log', wait: 30, match: :first)
+
+            expect(page).to have_text('Worker process completed.')
+
+            expect(Issue.published.count).to eq(1)
+          end
         end
       end
 
@@ -239,11 +260,10 @@ describe 'upload feature', js: true do
 
   describe 'CSV file samples' do
     before do
-      select 'Dradis::Plugins::CSV', from: 'uploader'
+      find('#uploader + .combobox').click
+      find('#uploader ~ .combobox-menu .combobox-option', text: 'Dradis::Plugins::CSV').click
 
-      within('.custom-file') do
-        page.find('#file', visible: false).attach_file(file_path)
-      end
+      attach_file 'file', file_path, visible: false, disabled: false
     end
 
     context 'uploading a malformed CSV file' do
@@ -265,16 +285,6 @@ describe 'upload feature', js: true do
 
         expect(page).to have_text('The uploaded file is not a CSV file.')
         expect(current_path).to eq(main_app.project_upload_manager_path(@project))
-      end
-    end
-
-    context 'uploading file with special characters in the filename' do
-      let(:file_path) { File.expand_path('../fixtures/files/simple (copy).csv', __dir__) }
-
-      it 'redirects to upload manager' do
-        find('body.upload.new', wait: 30)
-
-        expect(current_path).to eq(csv.new_project_upload_path(@project))
       end
     end
   end


### PR DESCRIPTION
### Spec
When uploading a CSV file, a user is able to choose the state. However, currently, this state isn't used in the backend at all.

**Proposed solution**

- Pass the chosen state to the uploads#new view
- From there, pass the state again when the mapping is submitted
- Update the Importer call to also pass the state


### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
