### PR TITLE
Add CSV to the Mappings Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.X.X (XXXX 2026)
+  - Add CSV to the Mappings Manager
+
 v5.0.0 (March 2026)
   - No changes
 

--- a/app/assets/javascripts/dradis/plugins/csv/upload.js
+++ b/app/assets/javascripts/dradis/plugins/csv/upload.js
@@ -77,10 +77,108 @@ document.addEventListener('turbo:load', function() {
       return valid;
     });
 
+    $(document).on('change', '[data-behavior~=dradis-field-select]', function () {
+      const $input = $(this).closest('td').find('[data-behavior~=custom-field-input]');
+      $input.toggleClass('d-none', $(this).val() !== 'Custom Field');
+      if ($(this).val() !== 'Custom Field') $input.val('');
+    });
+
+    $('[data-behavior~=save-mapping-checkbox]').on('change', function () {
+      $('[data-behavior~=save-mapping-name]').toggleClass('d-none', !$(this).is(':checked'));
+    });
+
+    $('[data-behavior~=saved-mapping-select]').on('change', function () {
+      const selectedOption = $(this).find('option:selected');
+      const fields = selectedOption.data('fields') || [];
+
+      // Reset every row to 'skip' so unmatched columns are excluded and
+      // re-applying a different mapping always starts from a clean state.
+      $('table tbody tr').each(function () {
+        const $row = $(this);
+        $row.find('[data-behavior~=type-select]').val('skip');
+        $row.removeClass('issue-type');
+        $row.find('[data-behavior~=custom-field-input]').addClass('d-none').val('');
+        $row.find('[data-behavior~=dradis-field-select]').attr('disabled', 'disabled').addClass('d-none');
+        $row.find('[data-behavior~=empty-field-select]').attr('disabled', 'disabled').removeClass('d-none');
+      });
+      $('[data-behavior~=type-select]').find('option[value="node"]').removeAttr('disabled');
+
+      const appliedRows = new Set();
+
+      fields.forEach(function (field) {
+        const sourceField = field.source_field;
+        const destField = field.destination_field;
+
+        let type, fieldName;
+        if (destField === 'Node Label') {
+          type = 'node';
+        } else if (destField === 'Issue ID') {
+          type = 'identifier';
+        } else if (destField.startsWith('Evidence: ')) {
+          type = 'evidence';
+          fieldName = destField.slice('Evidence: '.length);
+        } else if (destField.startsWith('Issue: ')) {
+          type = 'issue';
+          fieldName = destField.slice('Issue: '.length);
+        } else {
+          type = 'issue';
+          fieldName = destField;
+        }
+
+        $('table tbody tr').each(function (rowIndex) {
+          if (appliedRows.has(rowIndex)) return true;
+          const header = $(this).find('td:first').text().trim();
+          if (header === sourceField) {
+            appliedRows.add(rowIndex);
+            const $row = $(this);
+
+            const typeSelectEl = $row.find('[data-behavior~=type-select]')[0];
+            if (typeSelectEl) typeSelectEl.value = type;
+            $row.toggleClass('issue-type', type === 'issue');
+
+            $row.find('[data-behavior~=custom-field-input]').addClass('d-none').val('');
+            $row.find('[data-behavior~=dradis-field-select]').attr('disabled', 'disabled').addClass('d-none');
+
+            if (type === 'issue') {
+              $row.find('[data-behavior~=issue-field-select]').removeAttr('disabled').removeClass('d-none');
+            } else if (type === 'evidence') {
+              $row.find('[data-behavior~=evidence-field-select]').removeAttr('disabled').removeClass('d-none');
+            } else {
+              $row.find('[data-behavior~=empty-field-select]').attr('disabled', 'disabled').removeClass('d-none');
+            }
+
+            if (type === 'node') {
+              $('[data-behavior~=type-select]').not($row.find('[data-behavior~=type-select]'))
+                .find('option[value="node"]').attr('disabled', 'disabled');
+            }
+
+            setTimeout(function () {
+              if (type === 'issue' || type === 'evidence') {
+                const behavior = type === 'issue' ? 'issue-field-select' : 'evidence-field-select';
+                const $fieldSelect = $row.find(`[data-behavior~=${behavior}]`);
+                if (fieldName === 'Custom Field') {
+                  $fieldSelect.val('Custom Field').trigger('change');
+                } else {
+                  $fieldSelect.val(fieldName);
+                  if (!$fieldSelect.val()) {
+                    $fieldSelect.val('Custom Field').trigger('change');
+                    $row.find('[data-behavior~=custom-field-input]').val(fieldName);
+                  }
+                }
+              }
+            }, 0);
+            return false;
+          }
+        });
+      });
+    });
+
     // Private methods
 
     function _setDradisFieldSelect($select) {
       var $row = $select.closest('tr');
+
+      $row.find('[data-behavior~=custom-field-input]').addClass('d-none').val('');
 
       $row
         .find('[data-behavior~=dradis-field-select]')

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -65,7 +65,7 @@ module Dradis::Plugins::CSV
     end
 
     def load_saved_mappings
-      @saved_mappings = ::Mapping.where(component: 'csv').includes(:mapping_fields)
+      @saved_mappings = defined?(::Mapping) ? ::Mapping.where(component: 'csv').includes(:mapping_fields) : []
     end
 
     def build_mapping_fields(mapping, headers)
@@ -103,6 +103,8 @@ module Dradis::Plugins::CSV
     end
 
     def save_csv_mapping
+      return unless defined?(::Mapping)
+
       rtp = current_project.report_template_properties
       return unless rtp
 

--- a/app/controllers/dradis/plugins/csv/upload_controller.rb
+++ b/app/controllers/dradis/plugins/csv/upload_controller.rb
@@ -5,6 +5,7 @@ module Dradis::Plugins::CSV
     before_action :load_attachment, only: [:new, :create]
     before_action :load_rtp_fields, only: [:new]
     before_action :load_csv_headers, only: [:new]
+    before_action :load_saved_mappings, only: [:new]
 
     def new
       @default_columns = ['Column Header', 'Entity', 'Dradis Field']
@@ -13,6 +14,8 @@ module Dradis::Plugins::CSV
     end
 
     def create
+      save_csv_mapping if save_mapping?
+
       job_logger.write 'Enqueueing job to start in the background.'
 
       MappingImportJob.perform_later(
@@ -61,8 +64,61 @@ module Dradis::Plugins::CSV
         end
     end
 
+    def load_saved_mappings
+      @saved_mappings = ::Mapping.where(component: 'csv').includes(:mapping_fields)
+    end
+
+    def build_mapping_fields(mapping, headers)
+      mappings_params[:field_attributes].each do |index, attrs|
+        type = attrs['type']
+        header = headers[index.to_i]
+
+        next if type == 'skip' || header.blank?
+
+        destination_field = destination_field_for(type, attrs['field'], attrs['custom_field'])
+        next if destination_field.blank?
+
+        ::MappingField.create!(
+          content: header,
+          destination_field: destination_field,
+          mapping: mapping,
+          source_field: header
+        )
+      end
+    end
+
+    def destination_field_for(type, field, custom_field = nil)
+      name = field == 'Custom Field' ? custom_field : field
+      case type
+      when 'node'       then 'Node Label'
+      when 'identifier' then 'Issue ID'
+      when 'issue'      then "Issue: #{name}" if name.present?
+      when 'evidence'   then "Evidence: #{name}" if name.present?
+      else field
+      end
+    end
+
     def mappings_params
-      params.require(:mappings).permit(field_attributes: [:field, :type])
+      params.require(:mappings).permit(field_attributes: %i[custom_field field type])
+    end
+
+    def save_csv_mapping
+      rtp = current_project.report_template_properties
+      return unless rtp
+
+      mapping = ::Mapping.find_or_initialize_by(
+        component: 'csv',
+        source: params[:mapping_source_name]
+      )
+      mapping.destination = "rtp_#{rtp.id}"
+      return unless mapping.save
+
+      mapping.mapping_fields.destroy_all
+      build_mapping_fields(mapping, ::CSV.open(@attachment.fullpath, &:readline))
+    end
+
+    def save_mapping?
+      params[:save_mapping] == '1' && params[:mapping_source_name].present?
     end
 
     def state

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -22,6 +22,21 @@
     </div>
   </div>
 
+  <% if @saved_mappings.any? %>
+    <div class="mb-4" data-behavior="saved-mapping-selector">
+      <label class="form-label" for="saved_mapping">Load Saved Mapping</label>
+      <select id="saved_mapping" class="form-select" data-behavior="saved-mapping-select">
+        <option value="">— Select a saved mapping —</option>
+        <% @saved_mappings.each do |mapping| %>
+          <option value="<%= mapping.id %>"
+                  data-fields="<%= mapping.mapping_fields.map { |mf| { source_field: mf.source_field, destination_field: mf.destination_field } }.to_json %>">
+            <%= mapping.source %>
+          </option>
+        <% end %>
+      </select>
+    </div>
+  <% end %>
+
   <%= form_with url: project_upload_index_path(current_project, format: :js), method: :post, local: false, data: { behavior: 'mapping-form' } do |f| %>
     <%= hidden_field_tag 'log_uid', @log_uid %>
     <%= hidden_field_tag 'job_id', params[:job_id] %>
@@ -48,13 +63,15 @@
             <td>
               <% if @rtp_fields %>
                 <div>
-                  <% issue_options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue]) : options_for_select([[header, header]], disabled: header, selected: header) %>
+                  <% issue_options = @rtp_fields[:issue].any? ? options_for_select(@rtp_fields[:issue] + ['Custom Field']) : options_for_select([[header, header]], disabled: header, selected: header) %>
                   <%= f.select "mappings[field_attributes][#{index}][field]", issue_options, {}, class: 'form-select w-75 field-select', data: { behavior: 'dradis-field-select issue-field-select', header: header, 'combobox-config': 'no-combobox' } %>
 
-                  <% evidence_options = @rtp_fields[:evidence].any? ? options_for_select(@rtp_fields[:evidence]) : options_for_select([[header, header]], disabled: header, selected: header) %>
+                  <% evidence_options = @rtp_fields[:evidence].any? ? options_for_select(@rtp_fields[:evidence] + ['Custom Field']) : options_for_select([[header, header]], disabled: header, selected: header) %>
                   <%= f.select "mappings[field_attributes][#{index}][field]", evidence_options, {}, disabled: true, class: 'form-select w-75 field-select d-none', data: { behavior: 'dradis-field-select evidence-field-select', header: header, 'combobox-config': 'no-combobox' } %>
 
                   <%= f.select "mappings[field_attributes][#{index}][field]", [['N/A', '']], {}, disabled: true, class: 'form-select w-75 field-select d-none', data: { behavior: 'dradis-field-select empty-field-select', header: header, 'combobox-config': 'no-combobox' } %>
+
+                  <%= f.text_field "mappings[field_attributes][#{index}][custom_field]", class: 'form-control w-75 mt-1 d-none', placeholder: 'Custom field name', data: { behavior: 'custom-field-input' } %>
                 </div>
               <% else %>
                 <span data-behavior="field-label" data-header="<%= header.delete(" \t\r\n") %>" ><%= header.delete(" \t\r\n") %></span>
@@ -65,6 +82,15 @@
       </tbody>
     </table>
     <div class="form-actions">
+      <div class="mb-2">
+        <div class="form-check">
+          <%= check_box_tag :save_mapping, '1', false, class: 'form-check-input', data: { behavior: 'save-mapping-checkbox' } %>
+          <%= label_tag :save_mapping, 'Save this mapping for later', class: 'form-check-label' %>
+        </div>
+        <div class="mt-2 d-none" data-behavior="save-mapping-name">
+          <%= text_field_tag :mapping_source_name, '', class: 'form-control w-auto', placeholder: 'Mapping name (e.g. Prowler, ScoutSuite)' %>
+        </div>
+      </div>
       <%= f.submit 'Import CSV', class: 'btn btn-primary me-1', data: { disable_with: false } %> or
       <%= link_to 'Cancel', main_app.project_upload_manager_path(current_project) %>
     </div>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -26,7 +26,7 @@
     <div class="mb-4" data-behavior="saved-mapping-selector">
       <label class="form-label" for="saved_mapping">Load Saved Mapping</label>
       <select id="saved_mapping" class="form-select" data-behavior="saved-mapping-select">
-        <option value="">— Select a saved mapping —</option>
+        <option value="">Choose a saved mapping</option>
         <% @saved_mappings.each do |mapping| %>
           <option value="<%= mapping.id %>"
                   data-fields="<%= mapping.mapping_fields.map { |mf| { source_field: mf.source_field, destination_field: mf.destination_field } }.to_json %>">
@@ -83,13 +83,16 @@
     </table>
     <div class="form-actions">
       <% if defined?(::Mapping) %>
-        <div class="mb-2">
+        <div class="border-bottom mb-3 pb-2">
           <div class="form-check">
             <%= check_box_tag :save_mapping, '1', false, class: 'form-check-input', data: { behavior: 'save-mapping-checkbox' } %>
             <%= label_tag :save_mapping, 'Save this mapping for later', class: 'form-check-label' %>
           </div>
-          <div class="mt-2 d-none" data-behavior="save-mapping-name">
-            <%= text_field_tag :mapping_source_name, '', class: 'form-control w-auto', placeholder: 'Mapping name (e.g. Prowler, ScoutSuite)' %>
+          <div class="my-2 d-none" data-behavior="save-mapping-name">
+            <div class="ms-4">
+              <%= label_tag :mapping_source_name, 'Mapping Name', class: 'form-label' %>
+              <%= text_field_tag :mapping_source_name, '', class: 'form-control', placeholder: 'e.g. Web App Scan, Network Scan, Tool Name' %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/dradis/plugins/csv/upload/new.html.erb
+++ b/app/views/dradis/plugins/csv/upload/new.html.erb
@@ -82,15 +82,17 @@
       </tbody>
     </table>
     <div class="form-actions">
-      <div class="mb-2">
-        <div class="form-check">
-          <%= check_box_tag :save_mapping, '1', false, class: 'form-check-input', data: { behavior: 'save-mapping-checkbox' } %>
-          <%= label_tag :save_mapping, 'Save this mapping for later', class: 'form-check-label' %>
+      <% if defined?(::Mapping) %>
+        <div class="mb-2">
+          <div class="form-check">
+            <%= check_box_tag :save_mapping, '1', false, class: 'form-check-input', data: { behavior: 'save-mapping-checkbox' } %>
+            <%= label_tag :save_mapping, 'Save this mapping for later', class: 'form-check-label' %>
+          </div>
+          <div class="mt-2 d-none" data-behavior="save-mapping-name">
+            <%= text_field_tag :mapping_source_name, '', class: 'form-control w-auto', placeholder: 'Mapping name (e.g. Prowler, ScoutSuite)' %>
+          </div>
         </div>
-        <div class="mt-2 d-none" data-behavior="save-mapping-name">
-          <%= text_field_tag :mapping_source_name, '', class: 'form-control w-auto', placeholder: 'Mapping name (e.g. Prowler, ScoutSuite)' %>
-        </div>
-      </div>
+      <% end %>
       <%= f.submit 'Import CSV', class: 'btn btn-primary me-1', data: { disable_with: false } %> or
       <%= link_to 'Cancel', main_app.project_upload_manager_path(current_project) %>
     </div>

--- a/lib/dradis/plugins/csv.rb
+++ b/lib/dradis/plugins/csv.rb
@@ -8,4 +8,5 @@ end
 
 require 'dradis/plugins/csv/engine'
 require 'dradis/plugins/csv/importer'
+require 'dradis/plugins/csv/mapping'
 require 'dradis/plugins/csv/version'

--- a/lib/dradis/plugins/csv/importer.rb
+++ b/lib/dradis/plugins/csv/importer.rb
@@ -40,9 +40,15 @@ module Dradis::Plugins::CSV
       mappings.map do |index, mapping|
         next if project.report_template_properties && mapping['field'].blank?
 
-        field_name = project.report_template_properties ? mapping['field'] : row.headers[index.to_i].delete(" \t\r\n")
-        field_value = row[index.to_i]
-        "#[#{field_name}]#\n#{field_value}"
+        field_name = if project.report_template_properties
+          mapping['field'] == 'Custom Field' ? mapping['custom_field'] : mapping['field']
+        else
+          row.headers[index.to_i].delete(" \t\r\n")
+        end
+
+        next if field_name.blank?
+
+        "#[#{field_name}]#\n#{row[index.to_i]}"
       end.compact.join("\n\n")
     end
 

--- a/lib/dradis/plugins/csv/mapping.rb
+++ b/lib/dradis/plugins/csv/mapping.rb
@@ -1,0 +1,6 @@
+module Dradis::Plugins::CSV
+  module Mapping
+    DEFAULT_MAPPING = {}.freeze
+    SOURCE_FIELDS = {}.freeze
+  end
+end

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -282,6 +282,102 @@ describe 'upload feature', js: true do
     end
   end
 
+  context 'saving a mapping', js: true do
+    let(:file_path) { File.expand_path('../fixtures/files/simple.csv', __dir__) }
+    let(:rtp) do
+      create(:report_template_properties,
+        issue_fields: [{ name: 'Title', type: :string, default: true }],
+        evidence_fields: []
+      )
+    end
+
+    before do
+      @project.update(report_template_properties: rtp)
+
+      find('#state + .combobox').click
+      find('#state ~ .combobox-menu .combobox-option', text: 'Published').click
+
+      find('#uploader + .combobox').click
+      find('#uploader ~ .combobox-menu .combobox-option', text: 'Dradis::Plugins::CSV').click
+
+      attach_file 'file', file_path, visible: false, disabled: false
+      expect(page).to have_text('CSV Upload Mapping', wait: 30)
+    end
+
+    it 'creates a Mapping record when checkbox is checked and name is provided' do
+      select 'Issue ID', from: 'mappings[field_attributes][0][type]'
+      select 'Node', from: 'mappings[field_attributes][3][type]'
+      check 'save_mapping'
+      fill_in 'mapping_source_name', with: 'Prowler'
+
+      expect do
+        perform_enqueued_jobs { click_button 'Import CSV' }
+      end.to change(Mapping, :count).by(1)
+
+      mapping = Mapping.last
+      expect(mapping.source).to eq('Prowler')
+      expect(mapping.component).to eq('csv')
+      expect(mapping.mapping_fields.pluck(:destination_field)).to include('Issue ID', 'Node Label')
+    end
+
+    it 'does not create a Mapping record when checkbox is unchecked' do
+      select 'Issue ID', from: 'mappings[field_attributes][0][type]'
+      select 'Node', from: 'mappings[field_attributes][3][type]'
+
+      expect do
+        perform_enqueued_jobs { click_button 'Import CSV' }
+      end.not_to change(Mapping, :count)
+    end
+  end
+
+  context 'loading a saved mapping', js: true do
+    let(:file_path) { File.expand_path('../fixtures/files/simple.csv', __dir__) }
+    let(:rtp) do
+      create(:report_template_properties,
+        issue_fields: [{ name: 'Title', type: :string, default: true }],
+        evidence_fields: []
+      )
+    end
+    let!(:saved_mapping) do
+      mapping = Mapping.create!(
+        component: 'csv',
+        source: 'Test Mapping',
+        destination: "rtp_#{rtp.id}"
+      )
+      MappingField.create!(mapping: mapping, source_field: 'Title', destination_field: 'Issue ID', content: 'Title')
+      MappingField.create!(mapping: mapping, source_field: 'Description', destination_field: 'Issue: Title', content: 'Description')
+      mapping
+    end
+
+    before do
+      @project.update(report_template_properties: rtp)
+
+      find('#state + .combobox').click
+      find('#state ~ .combobox-menu .combobox-option', text: 'Published').click
+
+      find('#uploader + .combobox').click
+      find('#uploader ~ .combobox-menu .combobox-option', text: 'Dradis::Plugins::CSV').click
+
+      attach_file 'file', file_path, visible: false, disabled: false
+      expect(page).to have_text('CSV Upload Mapping', wait: 30)
+    end
+
+    it 'auto-fills rows matching the saved mapping' do
+      find('#saved_mapping + .combobox').click
+      find('#saved_mapping ~ .combobox-menu .combobox-option', text: 'Test Mapping').click
+
+      expect(page).to have_select('mappings[field_attributes][0][type]', selected: 'Issue ID')
+      expect(page).to have_select('mappings[field_attributes][1][type]', selected: 'Issue Field')
+    end
+
+    it 'resets rows not in the mapping to Do Not Import' do
+      find('#saved_mapping + .combobox').click
+      find('#saved_mapping ~ .combobox-menu .combobox-option', text: 'Test Mapping').click
+
+      expect(page).to have_select('mappings[field_attributes][2][type]', selected: 'Do Not Import')
+    end
+  end
+
   describe 'CSV file samples' do
     before do
       find('#uploader + .combobox').click

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -308,14 +308,14 @@ describe 'upload feature', js: true do
       select 'Issue ID', from: 'mappings[field_attributes][0][type]'
       select 'Node', from: 'mappings[field_attributes][3][type]'
       check 'save_mapping'
-      fill_in 'mapping_source_name', with: 'Prowler'
+      fill_in 'mapping_source_name', with: 'Web App Scan'
 
       expect do
         perform_enqueued_jobs { click_button 'Import CSV' }
       end.to change(Mapping, :count).by(1)
 
       mapping = Mapping.last
-      expect(mapping.source).to eq('Prowler')
+      expect(mapping.source).to eq('Web App Scan')
       expect(mapping.component).to eq('csv')
       expect(mapping.mapping_fields.pluck(:destination_field)).to include('Issue ID', 'Node Label')
     end

--- a/spec/lib/dradis/plugins/csv/importer_spec.rb
+++ b/spec/lib/dradis/plugins/csv/importer_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Dradis::Plugins::CSV::Importer do
         evidence = node.evidence.first
         expect(evidence.fields).to eq({ 'Label' => '10.0.0.1', 'Title' => '(No #[Title]# field)', 'MyLocation' => '10.0.0.1' })
       end
+
+      context 'when a custom field is selected' do
+        let(:mappings) do
+          {
+            '0' => { 'type' => 'identifier' },
+            '1' => { 'type' => 'issue', 'field' => 'Custom Field', 'custom_field' => 'MyCustomField' }
+          }
+        end
+
+        it 'uses the custom field name as the Dradis field' do
+          import_csv
+
+          issue = Issue.first
+          expect(issue.fields).to include('MyCustomField' => 'Test CSV')
+        end
+      end
     end
 
     context 'when project does not have RTP' do


### PR DESCRIPTION
### Summary

Allow the customizable CSV importer to have saved mappings and to use saved mappings


### Testing Steps
Prerequisites                                                                                                                                                                                            
- A project with a Report Template that has issue and/or evidence fields defined                                                                                                                         
- A CSV file whose column headers correspond to data you want to import (e.g. Title, Description, CVSSv2, Label, Location, Output)                                                                       
- The CSV file uploaded via Upload Manager (so it appears as an attachment)                                                                                                                              
                                                                                                                                                                                                         
1. Basic upload mapping (no saved mapping)                                                                                                                                                               
1. Go to Upload Manager → upload a CSV file                                                                                                                                                              
2. On the CSV Upload Mapping page, verify a row appears for each column header                                                                                                                           
3. Set one row to Issue ID — confirm the Dradis Field column shows N/A                                                                                                                                   
4. Set at least one row to Issue Field — confirm the Dradis Field dropdown populates with the report template's issue fields                                                                             
5. Set at least one row to Evidence Field — confirm a Node row must also be set (leave Node unset and try to submit — expect the node validation message)                                                
6. Set a Node row — confirm the Node option becomes disabled in all other Entity dropdowns                                                                                                               
7. Click Import CSV and confirm the import completes successfully                                                                                                                                        
                                                                                                                                                                                                         
2. Save a mapping                                                                                                                                                                                        
1. On the CSV Upload Mapping page, configure a valid mapping (Issue ID, at least one Issue Field, etc.)                                                                                                  
2. Check Save this mapping for later — confirm the mapping name input appears                                                                                                                            
3. Enter a name (e.g. Prowler) and click Import CSV                                                                                                                                                      
4. Navigate to Mappings Manager → CSV — confirm the new mapping appears with the correct Source Name and Destination Report Template                                                                     
                                                                                                                                                                                                         
3. Load a saved mapping                                   
1. Upload the same CSV file again to get back to the mapping page                                                                                                                                        
2. In the Load Saved Mapping dropdown, select the mapping saved in step 2                                                                                                                                
3. Confirm every row auto-fills correctly:                                                                                                                                                               
  - Rows in the saved mapping get the correct Entity and Dradis Field                                                                                                                                    
  - Rows not in the mapping reset to Do Not Import                                                                                                                                                       
  - The Issue ID row shows Issue ID in Entity and N/A in Dradis Field
  - The Node row shows Node in Entity and N/A in Dradis Field                                                                                                                                            
  - Node option is disabled in all other Entity dropdowns after Node is applied                                                                                                                          
4. Apply a second saved mapping — confirm all rows fully reset before the new mapping is applied (no stale values from the first)                                                                        
5. Click Import CSV and confirm the import succeeds                                                                                                                                                      
                                                                                                                                                                                                         
4. Custom fields                                                                                                                                                                                         
1. Save a mapping that includes a custom field (a field name not in the report template)                                                                                                                 
2. Reload the mapping on the upload page — confirm the custom field name appears in the text input below the Dradis Field dropdown                                                                       
                                                                                                                                                                                                         
5. Edge cases                                                                                                                                                                                            
- CSV with a column header that appears twice: confirm the mapping applies to the first matching row only; the second stays at Do Not Import                                                             
- Select Issue ID on two rows — confirm the validation message appears and submission is blocked                                                                                                         
- Select Evidence Field with no Node row — confirm the node validation message appears and submission is blocked   

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [X] Added a CHANGELOG entry
- [X] Added specs
